### PR TITLE
adds basic Object Oriented style relations on Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Gem Version](https://badge.fury.io/rb/investec_open_api.svg)](https://badge.fury.io/rb/investec_open_api)
 [![Build Status](https://travis-ci.com/Offerzen/investec_open_api.svg?branch=master)](https://travis-ci.com/Offerzen/investec_open_api)
 
-A simple client wrapper for the [Investec Open API](https://developer.investec.com/programmable-banking/#open-api). 
+A simple client wrapper for the [Investec Open API](https://developer.investec.com/programmable-banking/#open-api).
 
 *Features:*
 
@@ -64,6 +64,10 @@ Use the ID of one of your accounts to retrieve transactions:
 
 ```ruby
 client.transactions(my_account.id)
+
+# alternatively
+transactions = my_account.transactions
+account = transactions.first.account
 ```
 
 ## License

--- a/lib/investec_open_api.rb
+++ b/lib/investec_open_api.rb
@@ -1,5 +1,11 @@
 require "investec_open_api/version"
+require "investec_open_api/client"
+require "investec_open_api/exceptions/method_not_implemented_error"
+require "investec_open_api/exceptions/not_found_error"
+require "investec_open_api/models/relations"
 require "investec_open_api/models/base"
+require "investec_open_api/models/account"
+require "investec_open_api/models/transaction"
 
 module InvestecOpenApi
   class Error < StandardError; end

--- a/lib/investec_open_api/client.rb
+++ b/lib/investec_open_api/client.rb
@@ -1,7 +1,5 @@
 require "faraday"
 require "faraday_middleware"
-require "investec_open_api/models/account"
-require "investec_open_api/models/transaction"
 
 class InvestecOpenApi::Client
   def authenticate!

--- a/lib/investec_open_api/exceptions/method_not_implemented_error.rb
+++ b/lib/investec_open_api/exceptions/method_not_implemented_error.rb
@@ -1,0 +1,1 @@
+class InvestecOpenApi::MethodNotImplementedError < StandardError; end

--- a/lib/investec_open_api/exceptions/not_found_error.rb
+++ b/lib/investec_open_api/exceptions/not_found_error.rb
@@ -1,0 +1,1 @@
+class InvestecOpenApi::NotFoundError < StandardError; end

--- a/lib/investec_open_api/models/account.rb
+++ b/lib/investec_open_api/models/account.rb
@@ -6,6 +6,8 @@ module InvestecOpenApi::Models
     attribute :reference_name
     attribute :product_name
 
+    has_many :transactions, class_name: "Transaction"
+
     def self.from_api(params = {})
       if params['accountId'].present?
         params['id'] = params['accountId']
@@ -20,6 +22,17 @@ module InvestecOpenApi::Models
       end
 
       super
+    end
+
+    def self.find(id)
+      raise InvestecOpenApi::MethodNotImplementedError, ".find needs to be implemented"
+      # Options
+      # - client.accounts
+      # - from_api('accountId' => id)
+    end
+
+    def self.all
+      client.accounts
     end
   end
 end

--- a/lib/investec_open_api/models/account.rb
+++ b/lib/investec_open_api/models/account.rb
@@ -25,10 +25,10 @@ module InvestecOpenApi::Models
     end
 
     def self.find(id)
-      raise InvestecOpenApi::MethodNotImplementedError, ".find needs to be implemented"
-      # Options
-      # - client.accounts
-      # - from_api('accountId' => id)
+      account = all.find { |acc| acc.id == id }
+      raise InvestecOpenApi::NotFoundError unless account.present?
+
+      account
     end
 
     def self.all

--- a/lib/investec_open_api/models/base.rb
+++ b/lib/investec_open_api/models/base.rb
@@ -8,6 +8,7 @@ module InvestecOpenApi::Models
     @@client = -> do
       client = InvestecOpenApi::Client.new
       client.authenticate!
+      client
     end
 
     def self.client

--- a/lib/investec_open_api/models/base.rb
+++ b/lib/investec_open_api/models/base.rb
@@ -3,6 +3,16 @@ require "active_attr"
 module InvestecOpenApi::Models
   class Base
     include ActiveAttr::Model
+    extend InvestecOpenApi::Models::Relations
+
+    @@client = -> do
+      client = InvestecOpenApi::Client.new
+      client.authenticate!
+    end
+
+    def self.client
+      @@client.call
+    end
 
     def self.from_api(params = {})
       underscored_params = params.deep_transform_keys do |key|
@@ -11,5 +21,8 @@ module InvestecOpenApi::Models
 
       new(underscored_params)
     end
+
+    protected
+    attr_accessor :client
   end
 end

--- a/lib/investec_open_api/models/relations.rb
+++ b/lib/investec_open_api/models/relations.rb
@@ -1,0 +1,24 @@
+module InvestecOpenApi::Models
+  module Relations
+    extend self
+
+    def has_many(relation, params)
+      raise "RelationshipError: A valid class_name is required" unless params[:class_name]
+
+      self.define_method(relation) do
+        klass = Object.const_get("#{self.class.module_parent}::#{params[:class_name]}")
+        klass.where("#{self.class.to_s.split("::")[-1].downcase}_id".to_sym => self.id)
+      end
+    end
+
+    def belongs_to(relation, params)
+      raise "RelationshipError: A valid class_name is required" unless params[:class_name]
+
+      self.define_method(relation) do
+        klass = Object.const_get("#{self.class.module_parent}::#{params[:class_name]}")
+        klass.find(self.send("#{relation}_id".to_sym))
+      end
+    end
+
+  end
+end

--- a/lib/investec_open_api/models/transaction.rb
+++ b/lib/investec_open_api/models/transaction.rb
@@ -13,6 +13,13 @@ module InvestecOpenApi::Models
     attribute :value_date, type: Date
     attribute :action_date, type: Date
 
+    belongs_to :account, class_name: "Account"
+
+    def self.where(params = { account_id: nil })
+      raise InvestecOpenApi::NotFoundError, "a valid account_id my be specified" unless params[:account_id]
+      client.transactions(params[:account_id])
+    end
+
     # At this point, there is no unique identifier being returned from Investec's API.
     # This method serves to create a stable unique identifier based on the transaction details.
     def id

--- a/lib/investec_open_api/version.rb
+++ b/lib/investec_open_api/version.rb
@@ -1,3 +1,3 @@
 module InvestecOpenApi
-  VERSION = "1.0.1"
+  VERSION = "1.1.0"
 end

--- a/lib/investec_open_api/version.rb
+++ b/lib/investec_open_api/version.rb
@@ -1,3 +1,3 @@
 module InvestecOpenApi
-  VERSION = "1.1.0"
+  VERSION = "1.0.1"
 end

--- a/spec/lib/investec_open_api/models/account_spec.rb
+++ b/spec/lib/investec_open_api/models/account_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "investec_open_api/models/account"
 
 RSpec.describe InvestecOpenApi::Models::Account do
   describe "#from_api" do
@@ -12,7 +11,7 @@ RSpec.describe InvestecOpenApi::Models::Account do
           "referenceName" => "Savings Account",
           "productName" => "Private Bank Account"
         })
-  
+
         expect(model_instance.id).to eq "12345"
         expect(model_instance.number).to eq "67890"
         expect(model_instance.name).to eq "Test User"
@@ -36,6 +35,37 @@ RSpec.describe InvestecOpenApi::Models::Account do
 
         expect { model_instance.bank_account_number }.to raise_error(NoMethodError)
       end
+    end
+  end
+
+  describe "#transactions" do
+    let(:account) do
+      InvestecOpenApi::Models::Account.from_api({
+          "accountId" => "12345",
+          "accountNumber" => "67890",
+          "accountName" => "Test User",
+          "referenceName" => "Savings Account",
+          "productName" => "Private Bank Account"
+        })
+    end
+
+    it "responds to #transactions" do
+      expect(account.respond_to?(:transactions)).to be_truthy
+    end
+  end
+
+  describe ".find" do
+    xit "finds an account by its id"
+
+    it "raises a NotFoundError if no account is found" do
+      expect{described_class.find(1)}.to raise_error(InvestecOpenApi::MethodNotImplementedError)
+    end
+  end
+
+  describe ".all" do
+    it "queries all accessible accounts" do
+      expect_any_instance_of(InvestecOpenApi::Client).to receive(:accounts)
+      described_class.all
     end
   end
 end

--- a/spec/lib/investec_open_api/models/account_spec.rb
+++ b/spec/lib/investec_open_api/models/account_spec.rb
@@ -1,6 +1,24 @@
 require "spec_helper"
 
 RSpec.describe InvestecOpenApi::Models::Account do
+  before do
+    InvestecOpenApi.api_url = "https://openapistg.investec.com/"
+    InvestecOpenApi.api_username = "Test"
+    InvestecOpenApi.api_password = "Secret"
+
+    stub_request(:post, "#{InvestecOpenApi.api_url}identity/v2/oauth2/token")
+      .with(
+        body: "grant_type=client_credentials&scope=accounts",
+        headers: {
+          "Accept" => "application/json",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Authorization" => Faraday::Connection.new.basic_auth("Test", "Secret"),
+          "User-Agent" => "Faraday v1.0.1"
+        }
+      )
+      .to_return(body: { "access_token" => "123","token_type" => "Bearer", "expires_in" => 1799, "scope" =>"accounts" }.to_json)
+  end
+
   describe "#from_api" do
     context "with valid attributes" do
       it "returns a new instance of InvestecOpenApi::Models::Account with attributes" do
@@ -55,10 +73,49 @@ RSpec.describe InvestecOpenApi::Models::Account do
   end
 
   describe ".find" do
-    xit "finds an account by its id"
+    before do
+      stub_request(:get, "#{InvestecOpenApi.api_url}za/pb/v1/accounts")
+        .with(
+          body: "",
+          headers: {
+            "Accept" => "application/json",
+            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+            "Authorization" => "Bearer 123",
+            "User-Agent" => "Faraday v1.0.1"
+          }
+        )
+        .to_return(
+          body: {
+            data: {
+              accounts: [
+                {
+                  "accountId" => "12345",
+                  "accountNumber" => "67890",
+                  "accountName" => "Test User",
+                  "referenceName" => "My Private Investec Bank Account",
+                  "productName" => "Private Bank Account"
+                },
+                {
+                  "accountId" => "223344",
+                  "accountNumber" => "556677",
+                  "accountName" => "Test User",
+                  "referenceName" => "My Private Investec Savings Account",
+                  "productName" => "Private Savings Account"
+                }
+              ]
+            }
+          }.to_json
+        )
+    end
 
-    it "raises a NotFoundError if no account is found" do
-      expect{described_class.find(1)}.to raise_error(InvestecOpenApi::MethodNotImplementedError)
+    it "finds an account by its id" do
+      expect(described_class.find("12345")).to be_an_instance_of(described_class)
+    end
+
+    context "when an account does not exist" do
+      it "raises a NotFoundError if no account is found" do
+        expect{described_class.find("1")}.to raise_error(InvestecOpenApi::NotFoundError)
+      end
     end
   end
 

--- a/spec/lib/investec_open_api/models/base_spec.rb
+++ b/spec/lib/investec_open_api/models/base_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "investec_open_api/models/base"
 
 RSpec.describe InvestecOpenApi::Models::Base do
   describe "#from_api" do

--- a/spec/lib/investec_open_api/models/transaction_spec.rb
+++ b/spec/lib/investec_open_api/models/transaction_spec.rb
@@ -66,4 +66,48 @@ RSpec.describe InvestecOpenApi::Models::Transaction do
       expect(model_instance.id).to eq "-50000-COFFEE ORDER-2020-07-13"
     end
   end
+
+  describe "#account" do
+    let(:transaction) do
+      InvestecOpenApi::Models::Transaction.from_api({
+        "accountId" => "12345",
+        "type" => "DEBIT",
+        "status" => "POSTED",
+        "cardNumber" => "400000xxxxxx0001",
+        "amount" => 50000,
+        "description" => "COFFEE ORDER",
+        "transactionDate" => "2020-07-13",
+        "postingDate" => "2020-07-14",
+        "valueDate" => "2020-07-15",
+        "actionDate" => "2020-07-21"
+      })
+    end
+
+    it "responds to #account" do
+      expect(transaction.respond_to?(:account)).to be_truthy
+    end
+  end
+
+  describe ".where" do
+    let(:account) do
+      InvestecOpenApi::Models::Account.from_api({
+          "accountId" => "12345",
+          "accountNumber" => "67890",
+          "accountName" => "Test User",
+          "referenceName" => "Savings Account",
+          "productName" => "Private Bank Account"
+        })
+    end
+
+    it "finds all transactions that match an account" do
+      expect_any_instance_of(InvestecOpenApi::Client).to receive(:transactions).with(account.id)
+      described_class.where(account_id: account.id)
+    end
+
+    context "when an account_id is not specified" do
+      it "raises an error" do
+        expect{ described_class.where() }.to raise_error(InvestecOpenApi::NotFoundError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds basic Object Oriented style relations for `has_many` and `belongs_to` on Models.

# Description 

The aim is to give the gem a more natural feel that developers are used to.

```
# get all accounts
accounts = Account.all

# get a specific account
my_account = Account.find(1) #not yet implemented.

# see the transactions on an account
my_transactions = my_account.transactions

# get the account that a transaction belongs to
my_transactions.first.account
```

# Unresolved issues in this Pull Request
- ~failing tests: unclear on how to stub auth and web requests~
- ~unclear implementation of how the Account.find class method should be implemented~

# Version
Proposed version bump to 1.x.0
- no breaking changes
- 1 feature bump to the models for accessing entities.
