### PR TITLE
Polish/resolve dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,4 @@
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in investec_open_api.gemspec
-# gemspec
-
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"
-gem "active_attr"
-gem "money"
-gem "faraday"
-gem "faraday_middleware"
-gem "webmock"
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
     diff-lcs (1.4.4)
+    docile (1.1.5)
     erubi (1.9.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
@@ -52,6 +53,7 @@ GEM
     hashdiff (1.0.1)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    json (2.3.1)
     loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -90,6 +92,11 @@ GEM
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
     safe_yaml (1.0.5)
+    simplecov (0.12.0)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     thread_safe (0.3.6)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
@@ -107,6 +114,7 @@ DEPENDENCIES
   pry
   rake (~> 12.0)
   rspec (~> 3.0)
+  simplecov (~> 0.12.0)
   webmock
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+PATH
+  remote: .
+  specs:
+    investec_open_api (1.0.1)
+      active_attr
+      faraday
+      faraday_middleware
+      money
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -29,6 +38,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -40,11 +50,12 @@ GEM
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     hashdiff (1.0.1)
-    i18n (1.8.4)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    method_source (1.0.0)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
     money (6.13.8)
@@ -52,6 +63,9 @@ GEM
     multipart-post (2.1.1)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (4.0.5)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -89,10 +103,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  active_attr
-  faraday
-  faraday_middleware
-  money
+  investec_open_api!
+  pry
   rake (~> 12.0)
   rspec (~> 3.0)
   webmock

--- a/bin/console
+++ b/bin/console
@@ -7,8 +7,8 @@ require "investec_open_api"
 # with your gem easier. You can also use a different console, if you like.
 
 # (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
+require "pry"
+Pry.start
 
-require "irb"
-IRB.start(__FILE__)
+# require "irb"
+# IRB.start(__FILE__)

--- a/investec_open_api.gemspec
+++ b/investec_open_api.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "simplecov", "~> 0.12.0"
 end

--- a/investec_open_api.gemspec
+++ b/investec_open_api.gemspec
@@ -26,4 +26,14 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
+  spec.add_runtime_dependency "active_attr"
+  spec.add_runtime_dependency "money"
+  spec.add_runtime_dependency "faraday"
+  spec.add_runtime_dependency "faraday_middleware"
+
+  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "webmock"
+  spec.add_development_dependency "pry"
 end

--- a/lib/investec_open_api/models/relations.rb
+++ b/lib/investec_open_api/models/relations.rb
@@ -2,8 +2,10 @@ module InvestecOpenApi::Models
   module Relations
     extend self
 
+    class RelationshipError < StandardError; end
+
     def has_many(relation, params)
-      raise "RelationshipError: A valid class_name is required" unless params[:class_name]
+      raise RelationshipError, "A valid class_name is required" unless params[:class_name]
 
       self.define_method(relation) do
         klass = Object.const_get("#{self.class.module_parent}::#{params[:class_name]}")
@@ -12,13 +14,12 @@ module InvestecOpenApi::Models
     end
 
     def belongs_to(relation, params)
-      raise "RelationshipError: A valid class_name is required" unless params[:class_name]
+      raise RelationshipError, "A valid class_name is required" unless params[:class_name]
 
       self.define_method(relation) do
         klass = Object.const_get("#{self.class.module_parent}::#{params[:class_name]}")
         klass.find(self.send("#{relation}_id".to_sym))
       end
     end
-
   end
 end

--- a/spec/investec_open_api_spec.rb
+++ b/spec/investec_open_api_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe InvestecOpenApi do
   it "has a version number" do
-    expect(InvestecOpenApi::VERSION).not_to be nil
+    expect(InvestecOpenApi::VERSION).not_to be_nil
   end
 end

--- a/spec/lib/investec_open_api/client_spec.rb
+++ b/spec/lib/investec_open_api/client_spec.rb
@@ -1,8 +1,3 @@
-require "spec_helper"
-require "investec_open_api/client"
-require "investec_open_api/models/account"
-require "investec_open_api/models/transaction"
-
 RSpec.describe InvestecOpenApi::Client do
   let(:client) { InvestecOpenApi::Client.new }
 
@@ -80,7 +75,7 @@ RSpec.describe InvestecOpenApi::Client do
       expect(accounts.last.product_name).to eq "Private Savings Account"
     end
   end
- 
+
   describe "#transactions" do
     before do
       stub_request(:get, "#{InvestecOpenApi.api_url}za/pb/v1/accounts/12345/transactions")

--- a/spec/lib/investec_open_api/models/account_spec.rb
+++ b/spec/lib/investec_open_api/models/account_spec.rb
@@ -15,6 +15,47 @@ RSpec.describe InvestecOpenApi::Models::Account do
         }
       )
       .to_return(body: { "access_token" => "123","token_type" => "Bearer", "expires_in" => 1799, "scope" =>"accounts" }.to_json)
+
+    stub_request(:get, "#{InvestecOpenApi.api_url}za/pb/v1/accounts/12345/transactions")
+      .with(
+        body: "",
+        headers: {
+          "Accept" => "application/json",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Authorization" => "Bearer 123",
+          "User-Agent" => "Faraday v1.0.1"
+        }
+      )
+      .to_return(
+        body: {
+          data: {
+            transactions: [
+              {
+                "accountId": "12345",
+                "type": "DEBIT",
+                "status": "POSTED",
+                "description": "MONTHLY SERVICE CHARGE",
+                "cardNumber": "",
+                "postingDate": "2020-06-11",
+                "valueDate": "2020-06-10",
+                "actionDate": "2020-06-18",
+                "amount": 535
+              },
+              {
+                "accountId": "12345",
+                "type": "CREDIT",
+                "status": "POSTED",
+                "description": "CREDIT INTEREST",
+                "cardNumber": "",
+                "postingDate": "2020-06-11",
+                "valueDate": "2020-06-10",
+                "actionDate": "2020-06-18",
+                "amount": 31.09
+              }
+            ]
+          }
+        }.to_json
+      )
   end
 
   describe "#from_api" do
@@ -67,6 +108,14 @@ RSpec.describe InvestecOpenApi::Models::Account do
 
     it "responds to #transactions" do
       expect(account.respond_to?(:transactions)).to be_truthy
+    end
+
+    context "when the api returns transactions" do
+      it "returns the account's transactions" do
+        expected_transactions = account.transactions
+        expect(expected_transactions).to be_an_instance_of(Array)
+        expect(expected_transactions.first).to be_an_instance_of(InvestecOpenApi::Models::Transaction)
+      end
     end
   end
 

--- a/spec/lib/investec_open_api/models/account_spec.rb
+++ b/spec/lib/investec_open_api/models/account_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe InvestecOpenApi::Models::Account do
   describe "#from_api" do
     context "with valid attributes" do

--- a/spec/lib/investec_open_api/models/base_spec.rb
+++ b/spec/lib/investec_open_api/models/base_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe InvestecOpenApi::Models::Base do
   describe "#from_api" do
     it "returns a new instance of InvestecOpenApi::Models::Base without attributes" do

--- a/spec/lib/investec_open_api/models/transaction_spec.rb
+++ b/spec/lib/investec_open_api/models/transaction_spec.rb
@@ -1,4 +1,96 @@
 RSpec.describe InvestecOpenApi::Models::Transaction do
+  before do
+    InvestecOpenApi.api_url = "https://openapistg.investec.com/"
+    InvestecOpenApi.api_username = "Test"
+    InvestecOpenApi.api_password = "Secret"
+
+    stub_request(:post, "#{InvestecOpenApi.api_url}identity/v2/oauth2/token")
+      .with(
+        body: "grant_type=client_credentials&scope=accounts",
+        headers: {
+          "Accept" => "application/json",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Authorization" => Faraday::Connection.new.basic_auth("Test", "Secret"),
+          "User-Agent" => "Faraday v1.0.1"
+        }
+      )
+      .to_return(body: { "access_token" => "123","token_type" => "Bearer", "expires_in" => 1799, "scope" =>"accounts" }.to_json)
+
+    stub_request(:get, "#{InvestecOpenApi.api_url}za/pb/v1/accounts")
+      .with(
+        body: "",
+        headers: {
+          "Accept" => "application/json",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Authorization" => "Bearer 123",
+          "User-Agent" => "Faraday v1.0.1"
+        }
+      )
+      .to_return(
+        body: {
+          data: {
+            accounts: [
+              {
+                "accountId" => "12345",
+                "accountNumber" => "67890",
+                "accountName" => "Test User",
+                "referenceName" => "My Private Investec Bank Account",
+                "productName" => "Private Bank Account"
+              },
+              {
+                "accountId" => "223344",
+                "accountNumber" => "556677",
+                "accountName" => "Test User",
+                "referenceName" => "My Private Investec Savings Account",
+                "productName" => "Private Savings Account"
+              }
+            ]
+          }
+        }.to_json
+      )
+
+    stub_request(:get, "#{InvestecOpenApi.api_url}za/pb/v1/accounts/12345/transactions")
+      .with(
+        body: "",
+        headers: {
+          "Accept" => "application/json",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Authorization" => "Bearer 123",
+          "User-Agent" => "Faraday v1.0.1"
+        }
+      )
+      .to_return(
+        body: {
+          data: {
+            transactions: [
+              {
+                "accountId": "12345",
+                "type": "DEBIT",
+                "status": "POSTED",
+                "description": "MONTHLY SERVICE CHARGE",
+                "cardNumber": "",
+                "postingDate": "2020-06-11",
+                "valueDate": "2020-06-10",
+                "actionDate": "2020-06-18",
+                "amount": 535
+              },
+              {
+                "accountId": "12345",
+                "type": "CREDIT",
+                "status": "POSTED",
+                "description": "CREDIT INTEREST",
+                "cardNumber": "",
+                "postingDate": "2020-06-11",
+                "valueDate": "2020-06-10",
+                "actionDate": "2020-06-18",
+                "amount": 31.09
+              }
+            ]
+          }
+        }.to_json
+      )
+  end
+
   describe "#from_api" do
     context "with valid attributes" do
       it "returns a new instance of InvestecOpenApi::Models::Transaction with attributes" do
@@ -83,68 +175,16 @@ RSpec.describe InvestecOpenApi::Models::Transaction do
     it "responds to #account" do
       expect(transaction.respond_to?(:account)).to be_truthy
     end
+
+    context "when the api returns the account" do
+      it "returns the transaction's account" do
+        expected_account = transaction.account
+        expect(expected_account).to be_an_instance_of(InvestecOpenApi::Models::Account)
+      end
+    end
   end
 
   describe ".where" do
-    before do
-      InvestecOpenApi.api_url = "https://openapistg.investec.com/"
-      InvestecOpenApi.api_username = "Test"
-      InvestecOpenApi.api_password = "Secret"
-
-      stub_request(:post, "#{InvestecOpenApi.api_url}identity/v2/oauth2/token")
-        .with(
-          body: "grant_type=client_credentials&scope=accounts",
-          headers: {
-            "Accept" => "application/json",
-            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-            "Authorization" => Faraday::Connection.new.basic_auth("Test", "Secret"),
-            "User-Agent" => "Faraday v1.0.1"
-          }
-        )
-        .to_return(body: { "access_token" => "123","token_type" => "Bearer", "expires_in" => 1799, "scope" =>"accounts" }.to_json)
-
-      stub_request(:get, "#{InvestecOpenApi.api_url}za/pb/v1/accounts/12345/transactions")
-        .with(
-          body: "",
-          headers: {
-            "Accept" => "application/json",
-            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-            "Authorization" => "Bearer 123",
-            "User-Agent" => "Faraday v1.0.1"
-          }
-        )
-        .to_return(
-          body: {
-            data: {
-              transactions: [
-                {
-                  "accountId": "12345",
-                  "type": "DEBIT",
-                  "status": "POSTED",
-                  "description": "MONTHLY SERVICE CHARGE",
-                  "cardNumber": "",
-                  "postingDate": "2020-06-11",
-                  "valueDate": "2020-06-10",
-                  "actionDate": "2020-06-18",
-                  "amount": 535
-                },
-                {
-                  "accountId": "12345",
-                  "type": "CREDIT",
-                  "status": "POSTED",
-                  "description": "CREDIT INTEREST",
-                  "cardNumber": "",
-                  "postingDate": "2020-06-11",
-                  "valueDate": "2020-06-10",
-                  "actionDate": "2020-06-18",
-                  "amount": 31.09
-                }
-              ]
-            }
-          }.to_json
-        )
-    end
-
     let(:account) do
       InvestecOpenApi::Models::Account.from_api({
           "accountId" => "12345",
@@ -171,7 +211,7 @@ RSpec.describe InvestecOpenApi::Models::Transaction do
 
     context "when an account_id is not specified" do
       it "raises an error" do
-        expect{ described_class.where() }.to raise_error(InvestecOpenApi::NotFoundError)
+        expect{ described_class.where({}) }.to raise_error(InvestecOpenApi::NotFoundError)
       end
     end
   end

--- a/spec/lib/investec_open_api/models/transaction_spec.rb
+++ b/spec/lib/investec_open_api/models/transaction_spec.rb
@@ -1,6 +1,3 @@
-require "spec_helper"
-require "investec_open_api/models/transaction"
-
 RSpec.describe InvestecOpenApi::Models::Transaction do
   describe "#from_api" do
     context "with valid attributes" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,7 @@
+require 'simplecov'
+SimpleCov.start do
+  add_filter "/spec/"
+end
 require "rspec"
 require "bundler/setup"
 require "investec_open_api"


### PR DESCRIPTION
# Description
- Moves [dependencies](https://guides.rubygems.org/specification-reference/#add_development_dependency) from the  Gemfile to the [gemspec](https://bundler.io/man/gemfile.5.html#GEMSPEC)
- Centralises calls to `require`
- `./bin/console` works for development using Pry
- Adds test coverage using `simplecov`. View `coverage/index.html` in development.
- Improves test coverage for resolving the `has_many` and `belongs_to` relationships on models.

# Notes
- Stubbed web requests add many lines to the specs.