### PR TITLE
Add support for query parameters in transactions method and refactor code for DRYness

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in investec_open_api.gemspec
 gemspec
+
+gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,7 @@ GEM
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
@@ -74,6 +75,7 @@ GEM
     loofah (2.20.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    method_source (1.0.0)
     mini_portile2 (2.8.2)
     minitest (5.18.0)
     money (6.16.0)
@@ -82,6 +84,9 @@ GEM
     nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (5.0.1)
     racc (1.6.2)
     rack (2.2.7)
@@ -120,6 +125,7 @@ PLATFORMS
 
 DEPENDENCIES
   investec_open_api!
+  pry
   rake
   rspec
   webmock

--- a/bin/console
+++ b/bin/console
@@ -7,8 +7,8 @@ require "investec_open_api"
 # with your gem easier. You can also use a different console, if you like.
 
 # (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
+require "pry"
+Pry.start
 
-require "irb"
-IRB.start(__FILE__)
+# require "irb"
+# IRB.start(__FILE__)

--- a/lib/investec_open_api.rb
+++ b/lib/investec_open_api.rb
@@ -1,5 +1,6 @@
 require "investec_open_api/version"
 require "investec_open_api/models/base"
+require "investec_open_api/camel_case_refinement"
 require "investec_open_api/client"
 
 module InvestecOpenApi

--- a/lib/investec_open_api/camel_case_refinement.rb
+++ b/lib/investec_open_api/camel_case_refinement.rb
@@ -1,0 +1,12 @@
+module InvestecOpenApi
+  module CamelCaseRefinement
+    refine Hash do
+      def camelize
+        transform_keys do |key|
+          words = key.to_s.split('_')
+          words.drop(1).collect(&:capitalize).unshift(words.first).join
+        end
+      end
+    end
+  end
+end

--- a/lib/investec_open_api/client.rb
+++ b/lib/investec_open_api/client.rb
@@ -65,9 +65,4 @@ class InvestecOpenApi::Client
       builder.adapter Faraday.default_adapter
     end
   end
-
-  def camelize(snake_string)
-    words = snake_string.split('_')
-    words.drop(1).collect(&:capitalize).unshift(words.first).join
-  end
 end

--- a/lib/investec_open_api/client.rb
+++ b/lib/investec_open_api/client.rb
@@ -2,8 +2,10 @@ require "faraday"
 require "faraday_middleware"
 require "investec_open_api/models/account"
 require "investec_open_api/models/transaction"
+require "investec_open_api/camel_case_refinement"
 
 class InvestecOpenApi::Client
+  using InvestecOpenApi::CamelCaseRefinement
   INVESTEC_API_URL="https://openapi.investec.com/"
 
   def authenticate!
@@ -17,8 +19,15 @@ class InvestecOpenApi::Client
     end
   end
 
-  def transactions(account_id)
-    response = connection.get("za/pb/v1/accounts/#{account_id}/transactions")
+  def transactions(account_id, options = {})
+    endpoint_url = "za/pb/v1/accounts/#{account_id}/transactions"
+
+    unless options.empty?
+      query_string = URI.encode_www_form(options.camelize)
+      endpoint_url += "?#{query_string}"
+    end
+    
+    response = connection.get(endpoint_url)
     response.body["data"]["transactions"].map do |transaction_raw|
       InvestecOpenApi::Models::Transaction.from_api(transaction_raw)
     end
@@ -55,5 +64,10 @@ class InvestecOpenApi::Client
 
       builder.adapter Faraday.default_adapter
     end
+  end
+
+  def camelize(snake_string)
+    words = snake_string.split('_')
+    words.drop(1).collect(&:capitalize).unshift(words.first).join
   end
 end

--- a/spec/lib/investec_open_api/camel_case_refinement_spec.rb
+++ b/spec/lib/investec_open_api/camel_case_refinement_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+require 'investec_open_api/camel_case_refinement'
+
+RSpec.describe InvestecOpenApi::CamelCaseRefinement do
+  using InvestecOpenApi::CamelCaseRefinement
+
+  it 'converts snake_case keys to camelCase' do
+    hash = { 'first_key' => 1, 'second_key' => 2 }
+    expected = { 'firstKey' => 1, 'secondKey' => 2 }
+    expect(hash.camelize).to eq(expected)
+  end
+
+  it 'leaves keys without underscores unchanged' do
+    hash = { 'key' => 1 }
+    expect(hash.camelize).to eq(hash)
+  end
+
+  it 'handles empty hashes' do
+    expect({}.camelize).to eq({})
+  end
+end

--- a/spec/lib/investec_open_api/client_spec.rb
+++ b/spec/lib/investec_open_api/client_spec.rb
@@ -89,55 +89,76 @@ RSpec.describe InvestecOpenApi::Client do
   end
 
   describe "#transactions" do
-    before do
-      stub_request(:get, "#{api_url}za/pb/v1/accounts/12345/transactions")
-        .with(
-          body: "",
-          headers: {
-            "Accept" => "application/json",
-            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-            "Authorization" => "Bearer 123",
-            "User-Agent" => "Faraday v1.10.3"
-          }
-        )
-        .to_return(
-          body: {
-            data: {
-              transactions: [
-                {
-                  "accountId": "12345",
-                  "type": "DEBIT",
-                  "status": "POSTED",
-                  "description": "MONTHLY SERVICE CHARGE",
-                  "cardNumber": "",
-                  "postingDate": "2020-06-11",
-                  "valueDate": "2020-06-10",
-                  "actionDate": "2020-06-18",
-                  "amount": 535
-                },
-                {
-                  "accountId": "12345",
-                  "type": "CREDIT",
-                  "status": "POSTED",
-                  "description": "CREDIT INTEREST",
-                  "cardNumber": "",
-                  "postingDate": "2020-06-11",
-                  "valueDate": "2020-06-10",
-                  "actionDate": "2020-06-18",
-                  "amount": 31.09
-                }
-              ]
+    let(:transaction_data) do
+      {
+        data: {
+          transactions: [
+            {
+              "accountId": "12345",
+              "type": "DEBIT",
+              "status": "POSTED",
+              "description": "MONTHLY SERVICE CHARGE",
+              "cardNumber": "",
+              "postingDate": "2020-06-11",
+              "valueDate": "2020-06-10",
+              "actionDate": "2020-06-18",
+              "amount": 535
+            },
+            {
+              "accountId": "12345",
+              "type": "CREDIT",
+              "status": "POSTED",
+              "description": "CREDIT INTEREST",
+              "cardNumber": "",
+              "postingDate": "2020-06-11",
+              "valueDate": "2020-06-10",
+              "actionDate": "2020-06-18",
+              "amount": 31.09
             }
-          }.to_json
-        )
-
+          ]
+        }
+      }.to_json
+    end
+  
+    let(:headers) do
+      {
+        "Accept" => "application/json",
+        "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+        "Authorization" => "Bearer 123",
+        "User-Agent" => "Faraday v1.10.3"
+      }
+    end
+  
+    before do
       client.authenticate!
     end
-
-    it "returns all transactions for the specified account id as InvestecOpenApi::Models::Transaction instances" do
-      transactions = client.transactions("12345")
-
-      expect(transactions.first).to be_an_instance_of(InvestecOpenApi::Models::Transaction)
+  
+    context "when no filter parameters are specified" do
+      before do
+        stub_request(:get, "#{api_url}za/pb/v1/accounts/12345/transactions")
+          .with(body: "", headers: headers)
+          .to_return(body: transaction_data)
+      end
+  
+      it "returns all transactions for the specified account id as InvestecOpenApi::Models::Transaction instances" do
+        transactions = client.transactions("12345")
+        expect(transactions.first).to be_an_instance_of(InvestecOpenApi::Models::Transaction)
+      end
     end
+  
+    context "when filter parameters are specified" do
+      let(:options) { {from_date: "2021-01-01", to_date: "2023-01-01", page: 4} }
+  
+      before do
+        stub_request(:get, "#{api_url}za/pb/v1/accounts/12345/transactions?fromDate=2021-01-01&toDate=2023-01-01&page=4")
+          .with(body: "", headers: headers)
+          .to_return(body: transaction_data)
+      end
+  
+      it "returns all transactions for the specified account id as InvestecOpenApi::Models::Transaction instances" do
+        transactions = client.transactions("12345", options)
+        expect(transactions.first).to be_an_instance_of(InvestecOpenApi::Models::Transaction)
+      end
+    end  
   end
 end


### PR DESCRIPTION
# Description:
This PR introduces several changes to the `InvestecOpenApi::Client` class:

The transactions method now accepts an optional `options` hash parameter. This allows users to pass in query parameters such as `from_date`, `to_date`, and `page` when fetching transactions.

The keys in the `options` hash are converted from `snake_case` to `camelCase` to match the API's expected format. This is done using a Ruby refinement that adds a `#camelize` method to the Hash class.

The `camelize` method is defined in a new file, `lib/investec_open_api/camel_case_refinement.rb`.

The RSpec tests have been updated to include tests for the new functionality.

The code has been refactored for DRYness and readability.

# About the use of Ruby Refinements:
In this PR, a Ruby refinement is used to add a `#camelize` method to the Hash class. Refinements are a way to modify a class' behaviour within a specific scope, without affecting its behaviour globally. This is an advantage over traditional monkey patching, which affects the class globally and can lead to unexpected behaviour and conflicts.

The `camelize` refinement is activated within the `InvestecOpenApi::Client` class, which means it will only be available for use within this class. Even if this gem is used in a Rails application, the `camelize` refinement will not clash with Rails' `camelize` method or any other method named `camelize` because the refinement is not globally activated. Refinements are lexically scoped, which means they only apply to the file (and specifically the scope within that file) where they are explicitly activated with the `using` keyword. They do not leak into other classes, modules, or files unless explicitly activated in those scopes as well.

This approach ensures that the gem's internal modifications to the Hash class do not affect any other code that uses the Hash class, reducing the risk of method clashes and unexpected behaviour.