### PR TITLE
fixes deprecation warnings for rounding and localisation

### DIFF
--- a/lib/investec_open_api/models/transaction.rb
+++ b/lib/investec_open_api/models/transaction.rb
@@ -27,7 +27,10 @@ module InvestecOpenApi::Models
       if params['amount'].present?
         adjusted_amount = params['amount'] * 100
         adjusted_amount = -adjusted_amount if params['type'] == 'DEBIT'
-        params['amount'] = Money.new(adjusted_amount, "ZAR")
+        
+        Money.rounding_mode = BigDecimal::ROUND_HALF_UP
+        Money.locale_backend = :i18n
+        params['amount'] = Money.from_cents(adjusted_amount, "ZAR")
       end
 
       if params['transactionDate']

--- a/spec/lib/investec_open_api/models/transaction_spec.rb
+++ b/spec/lib/investec_open_api/models/transaction_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe InvestecOpenApi::Models::Transaction do
           "type" => "DEBIT",
           "status" => "POSTED",
           "cardNumber" => "400000xxxxxx0001",
-          "amount" => 50000,
+          "amount" => 50000.32,
           "description" => "COFFEE",
           "transactionDate" => "2020-07-13",
           "postingDate" => "2020-07-14",
@@ -23,7 +23,8 @@ RSpec.describe InvestecOpenApi::Models::Transaction do
         expect(model_instance.status).to eq "POSTED"
         expect(model_instance.card_number).to eq "400000xxxxxx0001"
         expect(model_instance.amount.class).to eq Money
-        expect(model_instance.amount.to_f).to eq -50000.0
+        expect(model_instance.amount.to_f).to eq -50000.32
+        expect(model_instance.amount.format).to eq "R-50,000.32"
         expect(model_instance.description).to eq "COFFEE"
         expect(model_instance.date).to eq Date.parse("2020-07-13")
         expect(model_instance.posting_date).to eq Date.parse("2020-07-14")


### PR DESCRIPTION
Fixes Deprecation warnings for future proofing:
- [DEPRECATION] You are using the default localization behaviour that will change in the next major release. Find out more - https://github.com/RubyMoney/money#deprecation
- [WARNING] The default rounding mode will change from `ROUND_HALF_EVEN` to `ROUND_HALF_UP` in the next major release. Set it explicitly using `Money.rounding_mode=` to avoid potential problems.